### PR TITLE
Remove "N60" from supported products list

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -25,6 +25,6 @@
 		"entrypoint": "../index.js"
 	},
 	"manufacturer": "Kiloview",
-	"products": ["N40", "N50", "N60", "N5", "N6"],
+	"products": ["N40", "N50", "N5", "N6"],
 	"keywords": ["NDI", "Video"]
 }


### PR DESCRIPTION
Per issue #10 and #14. Also tested on my own N60 on latest firmware, connection fails to login.

closes #10 
closes #14